### PR TITLE
Cambio de bit para poner LED en 1

### DIFF
--- a/adafruit.py
+++ b/adafruit.py
@@ -7,12 +7,18 @@ i2c = smbus.SMBus(1) #canal 1 de raspy
 
 nro_educiaa = 2
 slave_addr = 0x40
-base = 7+ (nro_educiaa-1)*16
+#LED_ON, LED_OFF control registers (address 06h to 45h)
+#LEDn_ON_L
+#LEDn_ON_H
+#LEDn_OFF_L
+#LEDn_OFF_H
+base = 7 + (nro_educiaa-1)*16 # LED0_ON_H = 07h
 host = "192.168.2.2"
 port = 8000
 
 
 #Bit SLEEP saca de modo Low power mode. Oscillator off ver referencia[2] en Mode Register 1 ( Pagina 14 )
+#MODE1[4] - Mode register 1 (address 00h) - Bit 4 SLEEP
 i2c.write_byte_data (slave_addr, 0x00, 0x01)
 
 def lee_estados(nro_educiaa):
@@ -24,12 +30,12 @@ def lee_estados(nro_educiaa):
     return leido
 
 def a_uno (puerto):
-    i2c.write_byte_data(slave_addr, base +4*puerto, 0x01)
-    i2c.write_byte_data(slave_addr, base+2+4*puerto, 0x00)
+    i2c.write_byte_data(slave_addr, base+4*puerto, 0x10) #LEDn_ON_H[4] (LEDn full ON)
+    i2c.write_byte_data(slave_addr, base+2+4*puerto, 0x00) #LEDn_OFF_H[4] (LEDn full OFF)
 
 def a_cero (puerto):
     i2c.write_byte_data(slave_addr, base+4*puerto, 0x00)
-    i2c.write_byte_data(slave_addr, base+2+4*puerto, 0x01)
+    i2c.write_byte_data(slave_addr, base+2+4*puerto, 0x10)
 
 #for puerto in range(4): 
 #    i2c.write_byte_data(slave_addr, base +4*puerto, 0x01)


### PR DESCRIPTION
El bit de los registros LEDn_ON_H y LEDn_OFF_H que controla el estado full ON y full OFF de los LEDs es el 4 y se estaba usando el 1.
Aparentemente el bit LED0_OFF_H[4] se puede dejar siempre en 0, de todas maneras mantuve esa parte del código.

![LED_00_OFF](https://user-images.githubusercontent.com/31114992/90966064-a4455c80-e4a4-11ea-843f-36454de703b3.PNG)
![LED_00_ON](https://user-images.githubusercontent.com/31114992/90966062-9bed2180-e4a4-11ea-9625-3044eeaa0e6b.PNG)